### PR TITLE
use the correct encoding in the `decodeKludges` method

### DIFF
--- a/fidonet-squish.js
+++ b/fidonet-squish.js
@@ -224,8 +224,9 @@ Squish.prototype.decodeKludges = function(header, decodeOptions){
 	if( encoding === null ) encoding = options.defaultEncoding;
 	var re=/\u0001(.*?):\s*([^\u0001]*)/gm;
 	var parts;
+	var kludgesText = header.kludges.toString(encoding);
 	var kludges = [];
-	while ((parts=re.exec(header.kludges))!==null)
+	while ((parts=re.exec(kludgesText))!==null)
 	{
 		kludges.push(parts[1]+': '+parts[2]);
 	}


### PR DESCRIPTION
If I recall correctly, `header.kludges` is [a Node.js Buffer.](https://github.com/askovpen/node-fidonet-squish/blob/c65412262d35c101486dfc2f42e085342ba85c3b/fidonet-squish.js#L134)

By performing [`RegExp.prototype.exec`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec) on that Buffer you're implicitly calling `header.kludges.toString()` (without parameters) and [it defaults](http://nodejs.org/docs/latest/api/buffer.html#buffer_buf_tostring_encoding_start_end) to the `'utf8'` encoding (instead of the necessary `encoding` value that you determined above).

This pull request introduces an explicit `.toString` encoding and thus eliminates the problem.
